### PR TITLE
Add RangeFinderFactory for simplified range creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,31 @@ A high-performance .NET range query library for general numeric ranges.
 
 ## Quick Start
 
+### Construct a RangeFinder
+
 ```csharp
 using RangeFinder.Core;
 
 // Simple tuple-based creation
-var finder = RangeFinderFactory.Create(new[]
-{
+var finder = RangeFinderFactory.Create(
+[
     (1.0, 2.2, 100),
     (2.0, 3.2, 200),
     (3.0, 4.0, 300)
-});
+]);
 
+// Or create from NumericRange objects
+var ranges = new[]
+{
+    new NumericRange<double, int>(1.0, 2.2, 100),
+    new NumericRange<double, int>(2.0, 3.2, 200)
+};
+var finder2 = RangeFinderFactory.Create(ranges);
+```
+
+### Issue queries
+
+```csharp
 // Query overlapping ranges
 var values = finder.Query(2.0, 2.9);         // Returns: 100, 200
 var overlaps = finder.QueryRanges(2.0, 3.0); // Returns: [1.0,2.2]=100, [2.0,3.2]=200

--- a/README.md
+++ b/README.md
@@ -18,14 +18,13 @@ A high-performance .NET range query library for general numeric ranges.
 ```csharp
 using RangeFinder.Core;
 
-var ranges = new List<NumericRange<double, int>>
+// Simple tuple-based creation
+var finder = RangeFinderFactory.Create(new[]
 {
-    new(1.0, 2.2, 100),
-    new(2.0, 3.2, 200),
-    new(3.0, 4.0, 300)
-};
-
-var finder = new RangeFinder<double, int>(ranges);
+    (1.0, 2.2, 100),
+    (2.0, 3.2, 200),
+    (3.0, 4.0, 300)
+});
 
 // Query overlapping ranges
 var values = finder.Query(2.0, 2.9);         // Returns: 100, 200
@@ -78,8 +77,7 @@ tree.Add(1.0, 5.0, 42);
 var results = tree.Query(2.0, 4.0);
 
 // After  
-var ranges = new[] { new NumericRange<double, int>(1.0, 5.0, 42) };
-var finder = new RangeFinder<double, int>(ranges);
+var finder = RangeFinderFactory.Create(new[] { (1.0, 5.0, 42) });
 var results = finder.Query(2.0, 4.0); // Same API!
 ```
 

--- a/RangeFinder.Core/RangeFinder.Core.csproj
+++ b/RangeFinder.Core/RangeFinder.Core.csproj
@@ -7,7 +7,7 @@
         
         <!-- Package Information -->
         <PackageId>RangeFinder</PackageId>
-        <Version>0.1.3</Version>
+        <Version>0.1.4</Version>
         <Authors>dotnetduck</Authors>
         <Copyright>Copyright (c) 2025- dotnetduck@gmail.com</Copyright>
         <Description>A high-performance .NET range query library for general numeric ranges.</Description>

--- a/RangeFinder.Core/RangeFinderFactory.cs
+++ b/RangeFinder.Core/RangeFinderFactory.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Numerics;
+
+namespace RangeFinder.Core;
+
+public static class RangeFinderFactory
+{
+    /// <summary>
+    /// Creates a RangeFinder instance from a collection of NumericRange objects.
+    /// Type parameters will be inferred from the provided ranges.
+    /// </summary>
+    /// <typeparam name="TNumber">The numeric type for range boundaries</typeparam>
+    /// <typeparam name="TAssociated">The type of value associated with each range</typeparam>
+    /// <param name="ranges">Collection of ranges to index</param>
+    /// <returns>A new RangeFinder instance</returns>
+    /// <exception cref="ArgumentNullException">Thrown when ranges is null</exception>
+    public static RangeFinder<TNumber, TAssociated>
+    Create<TNumber, TAssociated>(IEnumerable<NumericRange<TNumber, TAssociated>> ranges)
+        where TNumber : INumber<TNumber>
+    {
+        if (ranges == null)
+            throw new ArgumentNullException(nameof(ranges), "Ranges collection cannot be null.");
+
+        return new RangeFinder<TNumber, TAssociated>(ranges);
+    }
+
+    /// <summary>
+    /// Creates a RangeFinder from a collection of value tuples representing ranges.
+    /// Convenient method for creating ranges from simple (start, end, value) tuples.
+    /// </summary>
+    /// <typeparam name="TNumber">The numeric type for range boundaries</typeparam>
+    /// <typeparam name="TAssociated">The type of value associated with each range</typeparam>
+    /// <param name="ranges">Collection of (start, end, value) tuples</param>
+    /// <returns>A new RangeFinder instance</returns>
+    /// <exception cref="ArgumentNullException">Thrown when ranges is null</exception>
+    public static RangeFinder<TNumber, TAssociated>
+    Create<TNumber, TAssociated>(IEnumerable<(TNumber Start, TNumber End, TAssociated Value)> ranges)
+        where TNumber : INumber<TNumber>
+    {
+        if (ranges == null)
+            throw new ArgumentNullException(nameof(ranges), "Ranges collection cannot be null.");
+
+        var numericRanges = ranges.Select(r => new NumericRange<TNumber, TAssociated>(r.Start, r.End, r.Value));
+        return new RangeFinder<TNumber, TAssociated>(numericRanges);
+    }
+
+    /// <summary>
+    /// Creates a RangeFinder for ranges without associated values (using range index as value).
+    /// Useful when you only need to know which ranges overlap, not their associated data.
+    /// </summary>
+    /// <typeparam name="TNumber">The numeric type for range boundaries</typeparam>
+    /// <param name="ranges">Collection of (start, end) tuples</param>
+    /// <returns>A new RangeFinder instance with int indices as associated values</returns>
+    /// <exception cref="ArgumentNullException">Thrown when ranges is null</exception>
+    public static RangeFinder<TNumber, int>
+    Create<TNumber>(IEnumerable<(TNumber Start, TNumber End)> ranges)
+        where TNumber : INumber<TNumber>
+    {
+        if (ranges == null)
+            throw new ArgumentNullException(nameof(ranges), "Ranges collection cannot be null.");
+
+        var numericRanges = ranges.Select((r, index) => new NumericRange<TNumber, int>(r.Start, r.End, index));
+        return new RangeFinder<TNumber, int>(numericRanges);
+    }
+
+    /// <summary>
+    /// Creates a RangeFinder from separate start, end, and value arrays.
+    /// All arrays must have the same length.
+    /// </summary>
+    /// <typeparam name="TNumber">The numeric type for range boundaries</typeparam>
+    /// <typeparam name="TAssociated">The type of value associated with each range</typeparam>
+    /// <param name="starts">Array of start values</param>
+    /// <param name="ends">Array of end values</param>
+    /// <param name="values">Array of associated values</param>
+    /// <returns>A new RangeFinder instance</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any array is null</exception>
+    /// <exception cref="ArgumentException">Thrown when arrays have different lengths</exception>
+    public static RangeFinder<TNumber, TAssociated>
+    Create<TNumber, TAssociated>(TNumber[] starts, TNumber[] ends, TAssociated[] values)
+        where TNumber : INumber<TNumber>
+    {
+        if (starts == null)
+            throw new ArgumentNullException(nameof(starts), "Starts array cannot be null.");
+        if (ends == null)
+            throw new ArgumentNullException(nameof(ends), "Ends array cannot be null.");
+        if (values == null)
+            throw new ArgumentNullException(nameof(values), "Values array cannot be null.");
+
+        if (starts.Length != ends.Length || starts.Length != values.Length)
+            throw new ArgumentException("All arrays must have the same length.");
+
+        var ranges = starts.Zip(ends, values)
+            .Select(tuple => new NumericRange<TNumber, TAssociated>(tuple.First, tuple.Second, tuple.Third));
+
+        return new RangeFinder<TNumber, TAssociated>(ranges);
+    }
+
+    /// <summary>
+    /// Creates a RangeFinder from separate start and end arrays with indices as values.
+    /// Both arrays must have the same length.
+    /// </summary>
+    /// <typeparam name="TNumber">The numeric type for range boundaries</typeparam>
+    /// <param name="starts">Array of start values</param>
+    /// <param name="ends">Array of end values</param>
+    /// <returns>A new RangeFinder instance with int indices as associated values</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any array is null</exception>
+    /// <exception cref="ArgumentException">Thrown when arrays have different lengths</exception>
+    public static RangeFinder<TNumber, int>
+    Create<TNumber>(TNumber[] starts, TNumber[] ends)
+        where TNumber : INumber<TNumber>
+    {
+        if (starts == null)
+            throw new ArgumentNullException(nameof(starts), "Starts array cannot be null.");
+        if (ends == null)
+            throw new ArgumentNullException(nameof(ends), "Ends array cannot be null.");
+
+        if (starts.Length != ends.Length)
+            throw new ArgumentException("Start and end arrays must have the same length.");
+
+        var ranges = starts.Zip(ends)
+            .Select((tuple, index) => new NumericRange<TNumber, int>(tuple.First, tuple.Second, index));
+
+        return new RangeFinder<TNumber, int>(ranges);
+    }
+
+    /// <summary>
+    /// Creates an empty RangeFinder instance for the specified types.
+    /// Might be useful for initialization when ranges will be added later or for edge cases.
+    /// Note that dynamic building of ranges is not supported so far.
+    /// </summary>
+    /// <typeparam name="TNumber">The numeric type for range boundaries</typeparam>
+    /// <typeparam name="TAssociated">The type of value associated with each range</typeparam>
+    /// <returns>An empty RangeFinder instance</returns>
+    public static RangeFinder<TNumber, TAssociated>
+    CreateEmpty<TNumber, TAssociated>()
+        where TNumber : INumber<TNumber>
+    {
+        return new RangeFinder<TNumber, TAssociated>([]);
+    }
+}

--- a/RangeFinder.IO/RangeFinderLoader.cs
+++ b/RangeFinder.IO/RangeFinderLoader.cs
@@ -1,0 +1,175 @@
+using RangeFinder.Core;
+using System.Numerics;
+
+namespace RangeFinder.IO;
+
+/// <summary>
+/// Loader for creating RangeFinder instances from CSV and Parquet files.
+/// Provides convenient methods to load range data from files and create optimized RangeFinder instances.
+/// </summary>
+public static class RangeFinderLoader
+{
+    /// <summary>
+    /// Creates a RangeFinder instance from a CSV file using default types (double, string).
+    /// </summary>
+    /// <param name="filePath">Path to the CSV file containing range data</param>
+    /// <returns>A new RangeFinder instance with double ranges and string values</returns>
+    /// <exception cref="ArgumentNullException">Thrown when filePath is null</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the specified file does not exist</exception>
+    public static RangeFinder<double, string> FromCsv(string filePath)
+    {
+        if (filePath == null)
+            throw new ArgumentNullException(nameof(filePath), "File path cannot be null.");
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"File not found: {filePath}");
+
+        var ranges = RangeSerializer.ReadCsv<double, string>(filePath);
+        return RangeFinderFactory.Create(ranges);
+    }
+
+    /// <summary>
+    /// Creates a RangeFinder instance from a CSV file with specified types.
+    /// </summary>
+    /// <typeparam name="TNumber">The numeric type for range boundaries</typeparam>
+    /// <typeparam name="TAssociated">The type of value associated with each range</typeparam>
+    /// <param name="filePath">Path to the CSV file containing range data</param>
+    /// <returns>A new RangeFinder instance</returns>
+    /// <exception cref="ArgumentNullException">Thrown when filePath is null</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the specified file does not exist</exception>
+    public static RangeFinder<TNumber, TAssociated> FromCsv<TNumber, TAssociated>(string filePath)
+        where TNumber : INumber<TNumber>
+    {
+        if (filePath == null)
+            throw new ArgumentNullException(nameof(filePath), "File path cannot be null.");
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"File not found: {filePath}");
+
+        var ranges = RangeSerializer.ReadCsv<TNumber, TAssociated>(filePath);
+        return RangeFinderFactory.Create(ranges);
+    }
+
+    /// <summary>
+    /// Creates a RangeFinder instance from a CSV file asynchronously using default types (double, string).
+    /// </summary>
+    /// <param name="filePath">Path to the CSV file containing range data</param>
+    /// <returns>A task that represents the asynchronous operation with a RangeFinder instance</returns>
+    /// <exception cref="ArgumentNullException">Thrown when filePath is null</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the specified file does not exist</exception>
+    public static async Task<RangeFinder<double, string>> FromCsvAsync(string filePath)
+    {
+        if (filePath == null)
+            throw new ArgumentNullException(nameof(filePath), "File path cannot be null.");
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"File not found: {filePath}");
+
+        var ranges = await RangeSerializer.ReadCsvAsync<double, string>(filePath);
+        return RangeFinderFactory.Create(ranges);
+    }
+
+    /// <summary>
+    /// Creates a RangeFinder instance from a CSV file asynchronously with specified types.
+    /// </summary>
+    /// <typeparam name="TNumber">The numeric type for range boundaries</typeparam>
+    /// <typeparam name="TAssociated">The type of value associated with each range</typeparam>
+    /// <param name="filePath">Path to the CSV file containing range data</param>
+    /// <returns>A task that represents the asynchronous operation with a RangeFinder instance</returns>
+    /// <exception cref="ArgumentNullException">Thrown when filePath is null</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the specified file does not exist</exception>
+    public static async Task<RangeFinder<TNumber, TAssociated>> FromCsvAsync<TNumber, TAssociated>(string filePath)
+        where TNumber : INumber<TNumber>
+    {
+        if (filePath == null)
+            throw new ArgumentNullException(nameof(filePath), "File path cannot be null.");
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"File not found: {filePath}");
+
+        var ranges = await RangeSerializer.ReadCsvAsync<TNumber, TAssociated>(filePath);
+        return RangeFinderFactory.Create(ranges);
+    }
+
+    /// <summary>
+    /// Creates a RangeFinder instance from a Parquet file using default types (double, string).
+    /// </summary>
+    /// <param name="filePath">Path to the Parquet file containing range data</param>
+    /// <returns>A new RangeFinder instance with double ranges and string values</returns>
+    /// <exception cref="ArgumentNullException">Thrown when filePath is null</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the specified file does not exist</exception>
+    public static RangeFinder<double, string> FromParquet(string filePath)
+    {
+        if (filePath == null)
+            throw new ArgumentNullException(nameof(filePath), "File path cannot be null.");
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"File not found: {filePath}");
+
+        var ranges = RangeSerializer.ReadParquet<double, string>(filePath);
+        return RangeFinderFactory.Create(ranges);
+    }
+
+    /// <summary>
+    /// Creates a RangeFinder instance from a Parquet file with specified types.
+    /// </summary>
+    /// <typeparam name="TNumber">The numeric type for range boundaries</typeparam>
+    /// <typeparam name="TAssociated">The type of value associated with each range</typeparam>
+    /// <param name="filePath">Path to the Parquet file containing range data</param>
+    /// <returns>A new RangeFinder instance</returns>
+    /// <exception cref="ArgumentNullException">Thrown when filePath is null</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the specified file does not exist</exception>
+    public static RangeFinder<TNumber, TAssociated> FromParquet<TNumber, TAssociated>(string filePath)
+        where TNumber : INumber<TNumber>
+    {
+        if (filePath == null)
+            throw new ArgumentNullException(nameof(filePath), "File path cannot be null.");
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"File not found: {filePath}");
+
+        var ranges = RangeSerializer.ReadParquet<TNumber, TAssociated>(filePath);
+        return RangeFinderFactory.Create(ranges);
+    }
+
+    /// <summary>
+    /// Creates a RangeFinder instance from a Parquet file asynchronously using default types (double, string).
+    /// </summary>
+    /// <param name="filePath">Path to the Parquet file containing range data</param>
+    /// <returns>A task that represents the asynchronous operation with a RangeFinder instance</returns>
+    /// <exception cref="ArgumentNullException">Thrown when filePath is null</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the specified file does not exist</exception>
+    public static async Task<RangeFinder<double, string>> FromParquetAsync(string filePath)
+    {
+        if (filePath == null)
+            throw new ArgumentNullException(nameof(filePath), "File path cannot be null.");
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"File not found: {filePath}");
+
+        var ranges = await RangeSerializer.ReadParquetAsync<double, string>(filePath);
+        return RangeFinderFactory.Create(ranges);
+    }
+
+    /// <summary>
+    /// Creates a RangeFinder instance from a Parquet file asynchronously with specified types.
+    /// </summary>
+    /// <typeparam name="TNumber">The numeric type for range boundaries</typeparam>
+    /// <typeparam name="TAssociated">The type of value associated with each range</typeparam>
+    /// <param name="filePath">Path to the Parquet file containing range data</param>
+    /// <returns>A task that represents the asynchronous operation with a RangeFinder instance</returns>
+    /// <exception cref="ArgumentNullException">Thrown when filePath is null</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the specified file does not exist</exception>
+    public static async Task<RangeFinder<TNumber, TAssociated>> FromParquetAsync<TNumber, TAssociated>(string filePath)
+        where TNumber : INumber<TNumber>
+    {
+        if (filePath == null)
+            throw new ArgumentNullException(nameof(filePath), "File path cannot be null.");
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"File not found: {filePath}");
+
+        var ranges = await RangeSerializer.ReadParquetAsync<TNumber, TAssociated>(filePath);
+        return RangeFinderFactory.Create(ranges);
+    }
+}

--- a/RangeFinder.Tests/RangeFinderFactoryTests.cs
+++ b/RangeFinder.Tests/RangeFinderFactoryTests.cs
@@ -1,0 +1,283 @@
+using RangeFinder.Core;
+
+namespace RangeFinder.Tests;
+
+/// <summary>
+/// Tests for RangeFinderFactory static methods.
+/// Validates different factory creation patterns and error handling.
+/// </summary>
+[TestFixture]
+public class RangeFinderFactoryTests
+{
+    [Test]
+    public void Create_FromNumericRanges_CreatesValidInstance()
+    {
+        var ranges = new[]
+        {
+            new NumericRange<double, string>(1.0, 2.0, "First"),
+            new NumericRange<double, string>(3.0, 4.0, "Second")
+        };
+
+        var rangeFinder = RangeFinderFactory.Create(ranges);
+
+        Assert.That(rangeFinder.Count, Is.EqualTo(2));
+        Assert.That(rangeFinder.LowerBound, Is.EqualTo(1.0));
+        Assert.That(rangeFinder.UpperBound, Is.EqualTo(4.0));
+    }
+
+    [Test]
+    public void Create_FromNumericRanges_NullInput_ThrowsArgumentNullException()
+    {
+#pragma warning disable CS8600 // Intentional null assignment for testing null handling
+        IEnumerable<NumericRange<double, string>> ranges = null;
+#pragma warning restore CS8600
+
+        var ex = Assert.Throws<ArgumentNullException>(() => RangeFinderFactory.Create(ranges));
+        Assert.That(ex.ParamName, Is.EqualTo("ranges"));
+    }
+
+    [Test]
+    public void Create_FromTuples_CreatesValidInstance()
+    {
+        var ranges = new[]
+        {
+            (1.0, 2.0, "First"),
+            (3.0, 4.0, "Second"),
+            (2.5, 3.5, "Third")
+        };
+
+        var rangeFinder = RangeFinderFactory.Create(ranges);
+
+        Assert.That(rangeFinder.Count, Is.EqualTo(3));
+        
+        var results = rangeFinder.QueryRanges(2.7).ToArray();
+        Assert.That(results, Has.Length.EqualTo(1));
+        Assert.That(results[0].Value, Is.EqualTo("Third"));
+    }
+
+    [Test]
+    public void Create_FromTuples_NullInput_ThrowsArgumentNullException()
+    {
+#pragma warning disable CS8600 // Intentional null assignment for testing null handling
+        IEnumerable<(double, double, string)> ranges = null;
+#pragma warning restore CS8600
+
+        var ex = Assert.Throws<ArgumentNullException>(() => RangeFinderFactory.Create(ranges));
+        Assert.That(ex.ParamName, Is.EqualTo("ranges"));
+    }
+
+    [Test]
+    public void Create_FromTuplesWithoutValues_CreatesInstanceWithIndices()
+    {
+        var ranges = new[]
+        {
+            (1.0, 2.0),
+            (3.0, 4.0),
+            (2.5, 3.5)
+        };
+
+        var rangeFinder = RangeFinderFactory.Create(ranges);
+
+        Assert.That(rangeFinder.Count, Is.EqualTo(3));
+        
+        var results = rangeFinder.QueryRanges(2.7).ToArray();
+        Assert.That(results, Has.Length.EqualTo(1));
+        Assert.That(results[0].Value, Is.EqualTo(2)); // Third range has index 2
+    }
+
+    [Test]
+    public void Create_FromTuplesWithoutValues_NullInput_ThrowsArgumentNullException()
+    {
+#pragma warning disable CS8600 // Intentional null assignment for testing null handling
+        IEnumerable<(double, double)> ranges = null;
+#pragma warning restore CS8600
+
+        var ex = Assert.Throws<ArgumentNullException>(() => RangeFinderFactory.Create(ranges));
+        Assert.That(ex.ParamName, Is.EqualTo("ranges"));
+    }
+
+    [Test]
+    public void Create_FromArrays_CreatesValidInstance()
+    {
+        var starts = new[] { 1.0, 3.0, 2.5 };
+        var ends = new[] { 2.0, 4.0, 3.5 };
+        var values = new[] { "First", "Second", "Third" };
+
+        var rangeFinder = RangeFinderFactory.Create(starts, ends, values);
+
+        Assert.That(rangeFinder.Count, Is.EqualTo(3));
+        
+        var results = rangeFinder.QueryRanges(2.7).ToArray();
+        Assert.That(results, Has.Length.EqualTo(1));
+        Assert.That(results[0].Value, Is.EqualTo("Third"));
+    }
+
+    [Test]
+    public void Create_FromArrays_NullStarts_ThrowsArgumentNullException()
+    {
+#pragma warning disable CS8600 // Intentional null assignment for testing null handling
+        double[] starts = null;
+#pragma warning restore CS8600
+        var ends = new[] { 2.0, 4.0 };
+        var values = new[] { "First", "Second" };
+
+        var ex = Assert.Throws<ArgumentNullException>(() => RangeFinderFactory.Create(starts, ends, values));
+        Assert.That(ex.ParamName, Is.EqualTo("starts"));
+    }
+
+    [Test]
+    public void Create_FromArrays_NullEnds_ThrowsArgumentNullException()
+    {
+        var starts = new[] { 1.0, 3.0 };
+#pragma warning disable CS8600 // Intentional null assignment for testing null handling
+        double[] ends = null;
+#pragma warning restore CS8600
+        var values = new[] { "First", "Second" };
+
+        var ex = Assert.Throws<ArgumentNullException>(() => RangeFinderFactory.Create(starts, ends, values));
+        Assert.That(ex.ParamName, Is.EqualTo("ends"));
+    }
+
+    [Test]
+    public void Create_FromArrays_NullValues_ThrowsArgumentNullException()
+    {
+        var starts = new[] { 1.0, 3.0 };
+        var ends = new[] { 2.0, 4.0 };
+#pragma warning disable CS8600 // Intentional null assignment for testing null handling
+        string[] values = null;
+#pragma warning restore CS8600
+
+        var ex = Assert.Throws<ArgumentNullException>(() => RangeFinderFactory.Create(starts, ends, values));
+        Assert.That(ex.ParamName, Is.EqualTo("values"));
+    }
+
+    [Test]
+    public void Create_FromArrays_DifferentLengths_ThrowsArgumentException()
+    {
+        var starts = new[] { 1.0, 3.0 };
+        var ends = new[] { 2.0, 4.0, 5.0 }; // Different length
+        var values = new[] { "First", "Second" };
+
+        var ex = Assert.Throws<ArgumentException>(() => RangeFinderFactory.Create(starts, ends, values));
+        Assert.That(ex.Message, Contains.Substring("same length"));
+    }
+
+    [Test]
+    public void Create_FromStartEndArrays_CreatesInstanceWithIndices()
+    {
+        var starts = new[] { 1.0, 3.0, 2.5 };
+        var ends = new[] { 2.0, 4.0, 3.5 };
+
+        var rangeFinder = RangeFinderFactory.Create(starts, ends);
+
+        Assert.That(rangeFinder.Count, Is.EqualTo(3));
+        
+        var results = rangeFinder.QueryRanges(2.7).ToArray();
+        Assert.That(results, Has.Length.EqualTo(1));
+        Assert.That(results[0].Value, Is.EqualTo(2)); // Third range has index 2
+    }
+
+    [Test]
+    public void Create_FromStartEndArrays_NullStarts_ThrowsArgumentNullException()
+    {
+#pragma warning disable CS8600 // Intentional null assignment for testing null handling
+        double[] starts = null;
+#pragma warning restore CS8600
+        var ends = new[] { 2.0, 4.0 };
+
+        var ex = Assert.Throws<ArgumentNullException>(() => RangeFinderFactory.Create(starts, ends));
+        Assert.That(ex.ParamName, Is.EqualTo("starts"));
+    }
+
+    [Test]
+    public void Create_FromStartEndArrays_NullEnds_ThrowsArgumentNullException()
+    {
+        var starts = new[] { 1.0, 3.0 };
+#pragma warning disable CS8600 // Intentional null assignment for testing null handling
+        double[] ends = null;
+#pragma warning restore CS8600
+
+        var ex = Assert.Throws<ArgumentNullException>(() => RangeFinderFactory.Create(starts, ends));
+        Assert.That(ex.ParamName, Is.EqualTo("ends"));
+    }
+
+    [Test]
+    public void Create_FromStartEndArrays_DifferentLengths_ThrowsArgumentException()
+    {
+        var starts = new[] { 1.0, 3.0 };
+        var ends = new[] { 2.0, 4.0, 5.0 }; // Different length
+
+        var ex = Assert.Throws<ArgumentException>(() => RangeFinderFactory.Create(starts, ends));
+        Assert.That(ex.Message, Contains.Substring("same length"));
+    }
+
+    [Test]
+    public void CreateEmpty_CreatesEmptyInstance()
+    {
+        var rangeFinder = RangeFinderFactory.CreateEmpty<double, string>();
+
+        Assert.That(rangeFinder.Count, Is.EqualTo(0));
+        Assert.That(rangeFinder.QueryRanges(1.0, 2.0), Is.Empty);
+        Assert.That(rangeFinder.QueryRanges(1.5), Is.Empty);
+    }
+
+    [Test]
+    public void CreateEmpty_WithDifferentTypes_WorksCorrectly()
+    {
+        var intRangeFinder = RangeFinderFactory.CreateEmpty<int, string>();
+        var floatRangeFinder = RangeFinderFactory.CreateEmpty<float, object>();
+
+        Assert.That(intRangeFinder.Count, Is.EqualTo(0));
+        Assert.That(floatRangeFinder.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Create_IntegerTypes_WorksCorrectly()
+    {
+        var ranges = new[]
+        {
+            (1, 5, "First"),
+            (3, 7, "Second"),
+            (10, 15, "Third")
+        };
+
+        var rangeFinder = RangeFinderFactory.Create(ranges);
+
+        Assert.That(rangeFinder.Count, Is.EqualTo(3));
+        
+        var results = rangeFinder.QueryRanges(4).ToArray();
+        Assert.That(results, Has.Length.EqualTo(2));
+        Assert.That(results.Select(r => r.Value), Contains.Item("First"));
+        Assert.That(results.Select(r => r.Value), Contains.Item("Second"));
+    }
+
+    [Test]
+    public void Create_EmptyCollections_WorksCorrectly()
+    {
+        var emptyRanges = Enumerable.Empty<NumericRange<double, string>>();
+        var emptyTuples = Enumerable.Empty<(double, double, string)>();
+        var emptySimpleTuples = Enumerable.Empty<(double, double)>();
+
+        var rangeFinder1 = RangeFinderFactory.Create(emptyRanges);
+        var rangeFinder2 = RangeFinderFactory.Create(emptyTuples);
+        var rangeFinder3 = RangeFinderFactory.Create(emptySimpleTuples);
+
+        Assert.That(rangeFinder1.Count, Is.EqualTo(0));
+        Assert.That(rangeFinder2.Count, Is.EqualTo(0));
+        Assert.That(rangeFinder3.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Create_EmptyArrays_WorksCorrectly()
+    {
+        var emptyStarts = new double[0];
+        var emptyEnds = new double[0];
+        var emptyValues = new string[0];
+
+        var rangeFinder1 = RangeFinderFactory.Create(emptyStarts, emptyEnds, emptyValues);
+        var rangeFinder2 = RangeFinderFactory.Create(emptyStarts, emptyEnds);
+
+        Assert.That(rangeFinder1.Count, Is.EqualTo(0));
+        Assert.That(rangeFinder2.Count, Is.EqualTo(0));
+    }
+}

--- a/RangeFinder.Tests/RangeFinderLoaderTests.cs
+++ b/RangeFinder.Tests/RangeFinderLoaderTests.cs
@@ -1,0 +1,362 @@
+using RangeFinder.Core;
+using RangeFinder.IO;
+
+namespace RangeFinder.Tests;
+
+/// <summary>
+/// Tests for RangeFinderLoader class.
+/// Validates CSV and Parquet file loading with various data types and error handling.
+/// </summary>
+[TestFixture]
+public class RangeFinderLoaderTests
+{
+    private string GetTempCsvPath() => Path.GetTempFileName().Replace(".tmp", ".csv");
+    private string GetTempParquetPath() => Path.GetTempFileName().Replace(".tmp", ".parquet");
+
+    [TearDown]
+    public void Cleanup()
+    {
+        // Clean up any temp files that might have been created
+        var tempFiles = Directory.GetFiles(Path.GetTempPath(), "tmp*.csv")
+            .Concat(Directory.GetFiles(Path.GetTempPath(), "tmp*.parquet"));
+
+        foreach (var file in tempFiles)
+        {
+            try { File.Delete(file); } catch { /* ignore cleanup errors */ }
+        }
+    }
+
+    #region CSV Tests
+
+    [Test]
+    public void FromCsv_DefaultTypes_CreatesValidRangeFinder()
+    {
+        var tempFilePath = GetTempCsvPath();
+        try
+        {
+            // Create test data
+            var testRanges = new[]
+            {
+                new NumericRange<double, string>(1.0, 2.0, "First"),
+                new NumericRange<double, string>(3.0, 4.0, "Second"),
+                new NumericRange<double, string>(2.5, 3.5, "Third")
+            };
+
+            // Save to CSV
+            testRanges.WriteCsv(tempFilePath);
+
+            // Load using loader
+            var rangeFinder = RangeFinderLoader.FromCsv(tempFilePath);
+
+            Assert.That(rangeFinder.Count, Is.EqualTo(3));
+            Assert.That(rangeFinder.LowerBound, Is.EqualTo(1.0));
+            Assert.That(rangeFinder.UpperBound, Is.EqualTo(4.0));
+
+            var results = rangeFinder.QueryRanges(2.7).ToArray();
+            Assert.That(results, Has.Length.EqualTo(1));
+            Assert.That(results[0].Value, Is.EqualTo("Third"));
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath)) File.Delete(tempFilePath);
+        }
+    }
+
+    [Test]
+    public void FromCsv_CustomTypes_CreatesValidRangeFinder()
+    {
+        var tempFilePath = GetTempCsvPath();
+        try
+        {
+            // Create test data with int ranges and int values
+            var testRanges = new[]
+            {
+                new NumericRange<int, int>(10, 20, 100),
+                new NumericRange<int, int>(30, 40, 200),
+                new NumericRange<int, int>(25, 35, 300)
+            };
+
+            // Save to CSV
+            testRanges.WriteCsv(tempFilePath);
+
+            // Load using loader with custom types
+            var rangeFinder = RangeFinderLoader.FromCsv<int, int>(tempFilePath);
+
+            Assert.That(rangeFinder.Count, Is.EqualTo(3));
+            var results = rangeFinder.QueryRanges(32).ToArray();
+            Assert.That(results, Has.Length.EqualTo(2));
+            Assert.That(results.Select(r => r.Value), Contains.Item(200));
+            Assert.That(results.Select(r => r.Value), Contains.Item(300));
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath)) File.Delete(tempFilePath);
+        }
+    }
+
+    [Test]
+    public async Task FromCsvAsync_DefaultTypes_CreatesValidRangeFinder()
+    {
+        var tempFilePath = GetTempCsvPath();
+        try
+        {
+            // Create test data
+            var testRanges = new[]
+            {
+                new NumericRange<double, string>(1.0, 2.0, "Async1"),
+                new NumericRange<double, string>(3.0, 4.0, "Async2")
+            };
+
+            // Save to CSV
+            await testRanges.WriteCsvAsync(tempFilePath);
+
+            // Load using async loader
+            var rangeFinder = await RangeFinderLoader.FromCsvAsync(tempFilePath);
+
+            Assert.That(rangeFinder.Count, Is.EqualTo(2));
+            var results = rangeFinder.QueryRanges(1.5).ToArray();
+            Assert.That(results, Has.Length.EqualTo(1));
+            Assert.That(results[0].Value, Is.EqualTo("Async1"));
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath)) File.Delete(tempFilePath);
+        }
+    }
+
+    [Test]
+    public async Task FromCsvAsync_CustomTypes_CreatesValidRangeFinder()
+    {
+        var tempFilePath = GetTempCsvPath();
+        try
+        {
+            // Create test data with decimal ranges
+            var testRanges = new[]
+            {
+                new NumericRange<decimal, int>(1.5m, 2.5m, 42),
+                new NumericRange<decimal, int>(3.1m, 4.1m, 84)
+            };
+
+            // Save to CSV
+            await testRanges.WriteCsvAsync(tempFilePath);
+
+            // Load using async loader with custom types
+            var rangeFinder = await RangeFinderLoader.FromCsvAsync<decimal, int>(tempFilePath);
+
+            Assert.That(rangeFinder.Count, Is.EqualTo(2));
+            var results = rangeFinder.QueryRanges(2.0m).ToArray();
+            Assert.That(results, Has.Length.EqualTo(1));
+            Assert.That(results[0].Value, Is.EqualTo(42));
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath)) File.Delete(tempFilePath);
+        }
+    }
+
+    [Test]
+    public void FromCsv_NullFilePath_ThrowsArgumentNullException()
+    {
+#pragma warning disable CS8600 // Intentional null assignment for testing null handling
+        string filePath = null;
+#pragma warning restore CS8600
+
+        var ex = Assert.Throws<ArgumentNullException>(() => RangeFinderLoader.FromCsv(filePath));
+        Assert.That(ex.ParamName, Is.EqualTo("filePath"));
+    }
+
+    [Test]
+    public void FromCsv_NonExistentFile_ThrowsFileNotFoundException()
+    {
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), "non_existent_file.csv");
+
+        var ex = Assert.Throws<FileNotFoundException>(() => RangeFinderLoader.FromCsv(nonExistentPath));
+        Assert.That(ex.Message, Contains.Substring(nonExistentPath));
+    }
+
+    [Test]
+    public void FromCsvAsync_NullFilePath_ThrowsArgumentNullException()
+    {
+#pragma warning disable CS8600 // Intentional null assignment for testing null handling
+        string filePath = null;
+#pragma warning restore CS8600
+
+        Assert.ThrowsAsync<ArgumentNullException>(() => RangeFinderLoader.FromCsvAsync(filePath));
+    }
+
+    #endregion
+
+    #region Parquet Tests
+
+    [Test]
+    public void FromParquet_DefaultTypes_CreatesValidRangeFinder()
+    {
+        var tempFilePath = GetTempParquetPath();
+        try
+        {
+            // Create test data
+            var testRanges = new[]
+            {
+                new NumericRange<double, string>(5.0, 6.0, "ParquetFirst"),
+                new NumericRange<double, string>(7.0, 8.0, "ParquetSecond"),
+                new NumericRange<double, string>(6.5, 7.5, "ParquetThird")
+            };
+
+            // Save to Parquet
+            testRanges.WriteParquet(tempFilePath);
+
+            // Load using loader
+            var rangeFinder = RangeFinderLoader.FromParquet(tempFilePath);
+
+            Assert.That(rangeFinder.Count, Is.EqualTo(3));
+            Assert.That(rangeFinder.LowerBound, Is.EqualTo(5.0));
+            Assert.That(rangeFinder.UpperBound, Is.EqualTo(8.0));
+
+            var results = rangeFinder.QueryRanges(6.8).ToArray();
+            Assert.That(results, Has.Length.EqualTo(1));
+            Assert.That(results[0].Value, Is.EqualTo("ParquetThird"));
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath)) File.Delete(tempFilePath);
+        }
+    }
+
+    [Test]
+    public void FromParquet_CustomTypes_CreatesValidRangeFinder()
+    {
+        var tempFilePath = GetTempParquetPath();
+        try
+        {
+            // Create test data with float ranges and int values
+            var testRanges = new[]
+            {
+                new NumericRange<float, int>(1.1f, 2.1f, 111),
+                new NumericRange<float, int>(3.1f, 4.1f, 222)
+            };
+
+            // Save to Parquet
+            testRanges.WriteParquet(tempFilePath);
+
+            // Load using loader with custom types
+            var rangeFinder = RangeFinderLoader.FromParquet<float, int>(tempFilePath);
+
+            Assert.That(rangeFinder.Count, Is.EqualTo(2));
+            var results = rangeFinder.QueryRanges(1.6f).ToArray();
+            Assert.That(results, Has.Length.EqualTo(1));
+            Assert.That(results[0].Value, Is.EqualTo(111));
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath)) File.Delete(tempFilePath);
+        }
+    }
+
+    [Test]
+    public async Task FromParquetAsync_DefaultTypes_CreatesValidRangeFinder()
+    {
+        var tempFilePath = GetTempParquetPath();
+        try
+        {
+            // Create test data
+            var testRanges = new[]
+            {
+                new NumericRange<double, string>(11.0, 12.0, "AsyncParquet1"),
+                new NumericRange<double, string>(13.0, 14.0, "AsyncParquet2")
+            };
+
+            // Save to Parquet
+            await testRanges.WriteParquetAsync(tempFilePath);
+
+            // Load using async loader
+            var rangeFinder = await RangeFinderLoader.FromParquetAsync(tempFilePath);
+
+            Assert.That(rangeFinder.Count, Is.EqualTo(2));
+            var results = rangeFinder.QueryRanges(11.5).ToArray();
+            Assert.That(results, Has.Length.EqualTo(1));
+            Assert.That(results[0].Value, Is.EqualTo("AsyncParquet1"));
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath)) File.Delete(tempFilePath);
+        }
+    }
+
+    [Test]
+    public void FromParquet_NullFilePath_ThrowsArgumentNullException()
+    {
+#pragma warning disable CS8600 // Intentional null assignment for testing null handling
+        string filePath = null;
+#pragma warning restore CS8600
+
+        var ex = Assert.Throws<ArgumentNullException>(() => RangeFinderLoader.FromParquet(filePath));
+        Assert.That(ex.ParamName, Is.EqualTo("filePath"));
+    }
+
+    [Test]
+    public void FromParquet_NonExistentFile_ThrowsFileNotFoundException()
+    {
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), "non_existent_file.parquet");
+
+        var ex = Assert.Throws<FileNotFoundException>(() => RangeFinderLoader.FromParquet(nonExistentPath));
+        Assert.That(ex.Message, Contains.Substring(nonExistentPath));
+    }
+
+    [Test]
+    public void FromParquetAsync_NullFilePath_ThrowsArgumentNullException()
+    {
+#pragma warning disable CS8600 // Intentional null assignment for testing null handling
+        string filePath = null;
+#pragma warning restore CS8600
+
+        Assert.ThrowsAsync<ArgumentNullException>(() => RangeFinderLoader.FromParquetAsync(filePath));
+    }
+
+    #endregion
+
+    #region Empty File Tests
+
+    [Test]
+    public void FromCsv_EmptyFile_CreatesEmptyRangeFinder()
+    {
+        var tempFilePath = GetTempCsvPath();
+        try
+        {
+            // Create empty CSV file with just headers
+            var emptyRanges = Enumerable.Empty<NumericRange<double, string>>();
+            emptyRanges.WriteCsv(tempFilePath);
+
+            var rangeFinder = RangeFinderLoader.FromCsv(tempFilePath);
+
+            Assert.That(rangeFinder.Count, Is.EqualTo(0));
+            Assert.That(rangeFinder.QueryRanges(1.0), Is.Empty);
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath)) File.Delete(tempFilePath);
+        }
+    }
+
+    [Test]
+    public void FromParquet_EmptyFile_CreatesEmptyRangeFinder()
+    {
+        var tempFilePath = GetTempParquetPath();
+        try
+        {
+            // Create empty Parquet file
+            var emptyRanges = Enumerable.Empty<NumericRange<double, string>>();
+            emptyRanges.WriteParquet(tempFilePath);
+
+            var rangeFinder = RangeFinderLoader.FromParquet(tempFilePath);
+
+            Assert.That(rangeFinder.Count, Is.EqualTo(0));
+            Assert.That(rangeFinder.QueryRanges(1.0), Is.Empty);
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath)) File.Delete(tempFilePath);
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Add static factory methods for cleaner range creation syntax
- Support tuple-based creation patterns: `(start, end, value)` and `(start, end)`
- Support array-based creation with separate start/end/value arrays
- Include comprehensive null validation and error handling
- Update README examples to showcase simpler factory usage

## Benefits
- Users don't need to explicitly specify generic type parameters
- Cleaner, more intuitive API for common creation patterns
- Maintains full type safety and performance
- Comprehensive test coverage with proper nullable handling

## Test plan
- [x] All factory creation patterns work correctly
- [x] Null validation throws appropriate ArgumentNullExceptions
- [x] Array length validation works properly
- [x] Type inference works correctly for various numeric types
- [x] Empty collection handling works as expected
- [x] Integration with existing RangeFinder functionality

🤖 Generated with [Claude Code](https://claude.ai/code)